### PR TITLE
[doc] Command lines cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ Alternatively, an automated [Python build script](launch_build.py) is available.
 This can help you streamline the building process:
 
 ```bash
-$: python launch_build.py -h
+python launch_build.py -h
+```
+```text
 usage: launch_build.py [-h] [-j NJOBS] [-n NAME] (-m {default,debug,relwithdebinfo,minimal} | -c [CONFIG ...])
 
 options:
@@ -82,8 +84,8 @@ either one of the already available modes (see the `m` option) or the flags
 passed via the `c` option. For example:
 
 ```bash
-$: python launch_build.py -m relwithdebinfo
-$: python launch_build.py -n mybuild -c="-Dminimal=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo"
+python launch_build.py -m relwithdebinfo
+python launch_build.py -n mybuild -c="-Dminimal=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo"
 ```
 
 ### Activating ROOT in your environment after installation
@@ -92,7 +94,7 @@ After the CMake build has finished without errors, you can set up your environme
 to use the ROOT installation you just created via a `thisroot` script, for
 example on a Unix system with the bash shell:
 
-```
-$: source <build_or_install_dir>/bin/thisroot.sh
+```sh
+source <build_or_install_dir>/bin/thisroot.sh
 ```
 

--- a/step_by_step_instructions.md
+++ b/step_by_step_instructions.md
@@ -17,8 +17,8 @@ And click on the `Fork` button in the top right of the web UI.
 You can now clone both repositories on your machine, e.g. via
 
 ```bash
-$: git clone https://github.com/YOURUSERNAME/root.git
-$: git clone https://github.com/YOURUSERNAME/roottest.git
+git clone https://github.com/YOURUSERNAME/root.git
+git clone https://github.com/YOURUSERNAME/roottest.git
 ```
 
 To track changes in the main repositories, add the `upstream` remotes.
@@ -26,13 +26,13 @@ To track changes in the main repositories, add the `upstream` remotes.
 Inside the `root` directory:
 
 ```bash
-$: git remote add upstream https://github.com/root-project/root.git
+git remote add upstream https://github.com/root-project/root.git
 ```
 
 Inside the `roottest` directory:
 
 ```bash
-$: git remote add upstream https://github.com/root-project/roottest.git
+git remote add upstream https://github.com/root-project/roottest.git
 ```
 
 ## 3. Create build and install directories
@@ -41,7 +41,7 @@ To keep things clean, it is suggested to create separate directories for the
 builds and for the installations.
 
 ```bash
-$: mkdir rootbuild rootinstall
+mkdir rootbuild rootinstall
 ```
 
 ## 4. Configure the CMake build
@@ -51,7 +51,7 @@ For the purposes of development and testing, the following configuration is
 suggested:
 
 ```bash
-$: cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -Dtesting=ON -Droottest=ON -DCMAKE_INSTALL_PREFIX=rootinstall/myinstall -B rootbuild/mybuild -S root
+cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -Dtesting=ON -Droottest=ON -DCMAKE_INSTALL_PREFIX=rootinstall/myinstall -B rootbuild/mybuild -S root
 ```
 
 The process of launching the Cmake build may be sped up by using the ccache package, if it is installed in the system. To activate it, add `-Dccache=ON` to variables.
@@ -61,7 +61,7 @@ The process of launching the Cmake build may be sped up by using the ccache pack
 Finally, you can launch the CMake build via:
 
 ```bash
-$: cmake --build rootbuild/mybuild --target install -jNPROC
+cmake --build rootbuild/mybuild --target install -jNPROC
 ```
 
-Where `NPROC` is the number of available cores you want to send in parallel for the build.
+where `NPROC` is the number of available cores you want to send in parallel for the build.


### PR DESCRIPTION
Command lines are rendered such that there is a pictogram on the right the viewer can click on and the command gets copied into the clipboard that can then be directly pasted into the terminal. This means the commands must be exactly what is used on the command line. This PR removes interfering leading command line characters.